### PR TITLE
Documentation fix for build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ docker-rsyslog
 
 Builds a docker image for rsyslog v8-stable.
 
-```docker build -t <user>/rsyslog```
+```docker build -t <user>/rsyslog .```
 
 Run the container:
 


### PR DESCRIPTION
In the build command you need to specify the location of the source to build, otherwise the build will not start.
